### PR TITLE
copyWith in Request fixed Uri error

### DIFF
--- a/packages/network/lib/src/request.dart
+++ b/packages/network/lib/src/request.dart
@@ -24,7 +24,7 @@ class Request {
   Request copyWith({
     Map<String, String> headers,
     Map<String, dynamic> queryParameters,
-    String url,
+    Uri url,
     Encoding encoding,
     Object body,
   }) =>


### PR DESCRIPTION
Hey, thank you for creating this repo! Here is what I did and some questions, be sure to edit this commit message when merging. Please read my question at the bottom as well.
copyWith function in the Request.dart was receiving String instead of Uri and thus resulting in an error and unusability of URL manipulation through this method. Now it is changed to accept Uri as intended instead of String.  Merge when possible. Also, a question does the onError interceptor work when added to the network settings? I'm not sure it does, can you help me how I can figure it out? Or maybe my usage is bad then you maybe want to consider giving a better example of that exact problem.

Have a nice day!